### PR TITLE
Automation Updates

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,24 @@
+### This is the Terraform-generated dev-build.yml workflow for the alma-sapinvoices-dev app repository ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document                   ###
+### If the container requires any additional pre-build commands, uncomment and edit                    ###
+### the PREBUILD line at the end of the document.                                                      ###
+name: Dev Container Build and Deploy
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  deploy:
+    name: Dev Container Deploy
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-dev.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE: "alma-sapinvoices-gha-dev"
+      ECR: "alma-sapinvoices-dev"
+      # FUNCTION: ""
+      # PREBUILD: 

--- a/.github/workflows/prod-promote.yml
+++ b/.github/workflows/prod-promote.yml
@@ -1,0 +1,21 @@
+### This is the Terraform-generated prod-promote.yml workflow for the alma-sapinvoices-prod repository. ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document.                   ###
+name: Prod Container Promote
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Prod Container Promote
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-promote-prod.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE_STAGE: alma-sapinvoices-gha-stage
+      GHA_ROLE_PROD: alma-sapinvoices-gha-prod
+      ECR_STAGE: "alma-sapinvoices-stage"
+      ECR_PROD: "alma-sapinvoices-prod"
+      # FUNCTION: ""
+ 

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -1,0 +1,24 @@
+### This is the Terraform-generated dev-build.yml workflow for the alma-sapinvoices-stage app repository ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document                     ###
+### If the container requires any additional pre-build commands, uncomment and edit                      ###
+### the PREBUILD line at the end of the document.                                                        ###
+name: Stage Container Build and Deploy
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  deploy:
+    name: Stage Container Deploy
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-stage.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE: "alma-sapinvoices-gha-stage"
+      ECR: "alma-sapinvoices-stage"
+      # FUNCTION: ""
+      # PREBUILD: 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+
+### This is the Terraform-generated header for alma-sapinvoices-dev. If  ###
+###   this is a Lambda repo, uncomment the FUNCTION line below           ###
+###   and review the other commented lines in the document.              ###
+ECR_NAME_DEV:=alma-sapinvoices-dev
+ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/alma-sapinvoices-dev
+# FUNCTION_DEV:=
+### End of Terraform-generated header                                    ###
 SHELL=/bin/bash
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
 
@@ -38,3 +46,41 @@ pylama:
 safety:
 	pipenv check
 	pipenv verify
+
+
+### Terraform-generated Developer Deploy Commands for Dev environment ###
+dist-dev: ## Build docker container (intended for developer-based manual build)
+	docker build --platform linux/amd64 \
+	    -t $(ECR_URL_DEV):latest \
+		-t $(ECR_URL_DEV):`git describe --always` \
+		-t $(ECR_NAME_DEV):latest .
+
+publish-dev: dist-dev ## Build, tag and push (intended for developer-based manual publish)
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_DEV)
+	docker push $(ECR_URL_DEV):latest
+	docker push $(ECR_URL_DEV):`git describe --always`
+
+### If this is a Lambda repo, uncomment the two lines below     ###
+# update-lambda-dev: ## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
+#	aws lambda update-function-code --function-name $(FUNCTION_DEV) --image-uri $(ECR_URL_DEV):latest
+
+
+### Terraform-generated manual shortcuts for deploying to Stage. This requires  ###
+###   that ECR_NAME_STAGE, ECR_URL_STAGE, and FUNCTION_STAGE environment        ###
+###   variables are set locally by the developer and that the developer has     ###
+###   authenticated to the correct AWS Account. The values for the environment  ###
+###   variables can be found in the stage_build.yml caller workflow.            ###
+dist-stage: ## Only use in an emergency
+	docker build --platform linux/amd64 \
+	    -t $(ECR_URL_STAGE):latest \
+		-t $(ECR_URL_STAGE):`git describe --always` \
+		-t $(ECR_NAME_STAGE):latest .
+
+publish-stage: ## Only use in an emergency
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_STAGE)
+	docker push $(ECR_URL_STAGE):latest
+	docker push $(ECR_URL_STAGE):`git describe --always`
+
+### If this is a Lambda repo, uncomment the two lines below     ###
+# update-lambda-stage: ## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
+#	aws lambda update-function-code --function-name $(FUNCTION_STAGE) --image-uri $(ECR_URL_STAGE):latest


### PR DESCRIPTION
### What does this PR do?

* Add Terraform-generated content to the Makefile to allow the developer to easily build and push containers to the Dev1 ECR repository from the local CLI
* Create the dev-build workflow (from the Terraform output) for automated container builds & uploads to Dev1 on pushes to any feature branch
* Create the stage-build workflow (from the Terraform output) for automated container builds & uploads to Stage-Workloads on any merges to the main branch
* Create the prod-promote workflow (from the Terraform output) for automated container uploads to Prod-Workloads on any tagged releases on the main branch

### Helpful background context

The ECR infrastructure for this application has already been deployed. The outputs from that Terraform run are provided here for the Makefile and the three GitHub Action workflows for automating the container publishing process to our AWS Organization.

### How can a reviewer manually see the effects of these changes?

The developer can use the new `make dist-dev` and `make publish-dev` from the local cli to verify that the container can be built and pushed to the ECR repository in Dev1. 

Testing of the automated workflows is difficult until they are merged to the `main` branch. They will run automatically, but cannot be triggered manually until they exist in `main`.

### Includes new or updated dependencies?

NO

### What are the relevant tickets?

* [IN-656](https://mitlibraries.atlassian.net/browse/IN-656)
* [IN-657](https://mitlibraries.atlassian.net/browse/IN-657)

### Developer

- [X] All new ENV is documented in README (or there is none)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes


[IN-656]: https://mitlibraries.atlassian.net/browse/IN-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ