### PR TITLE
Handle errors when marking invoices paid

### DIFF
--- a/sapinvoices/alma.py
+++ b/sapinvoices/alma.py
@@ -216,9 +216,7 @@ class AlmaClient:
         )
         result.raise_for_status()
         time.sleep(0.1)
-        if result.json()["payment"]["payment_status"]["value"] == "PAID":
-            return
-        else:
+        if not result.json()["payment"]["payment_status"]["value"] == "PAID":
             raise ValueError
 
     def process_invoice(self, invoice_id: str) -> dict:

--- a/sapinvoices/alma.py
+++ b/sapinvoices/alma.py
@@ -196,7 +196,7 @@ class AlmaClient:
         payment_date: datetime,
         payment_amount: str,
         payment_currency: str,
-    ) -> dict:
+    ) -> None:
         """Mark an invoice as paid using the invoice process endpoint."""
         endpoint = f"acq/invoices/{invoice_id}"
         params = {"op": "paid"}
@@ -216,7 +216,10 @@ class AlmaClient:
         )
         result.raise_for_status()
         time.sleep(0.1)
-        return result.json()
+        if result.json()["payment"]["payment_status"]["value"] == "PAID":
+            return
+        else:
+            raise ValueError
 
     def process_invoice(self, invoice_id: str) -> dict:
         """Move an invoice to in process using the invoice process endpoint."""

--- a/sapinvoices/sap.py
+++ b/sapinvoices/sap.py
@@ -632,18 +632,14 @@ def mark_invoices_paid(
         logger.debug("total amount: %s", invoice["total amount"])
         logger.debug("currency: %s", invoice["currency"])
         try:
-            response = alma_client.mark_invoice_paid(
+            alma_client.mark_invoice_paid(
                 invoice_id, date, invoice["total amount"], invoice["currency"]
             )
-            if response["payment"]["payment_status"]["value"] == "PAID":
-                logger.debug("Invoice '%s' marked as paid in Alma", invoice_id)
-                paid_invoice_count += 1
-            else:
-                raise ValueError
+
+            paid_invoice_count += 1
         except (requests.exceptions.RequestException, ValueError):
             logger.error(
-                "Something went wrong marking invoice '%s' paid in Alma, it "
-                "should be investigated manually",
+                "Something went wrong marking invoice '%s' paid in Alma.",
                 invoice_id,
             )
 

--- a/tests/test_alma.py
+++ b/tests/test_alma.py
@@ -121,7 +121,7 @@ def test_mark_invoice_paid(alma_client):
                 payment_amount=payment_amount,
                 payment_currency=payment_currency,
             )
-            == mocked_response
+            is None
         )
         assert mocker.last_request.url == test_url
         assert mocker.last_request.method == "POST"
@@ -157,6 +157,24 @@ def test_mark_invoice_paid_request_status_error(alma_client):
     with requests_mock.Mocker(case_sensitive=True) as mocker:
         mocker.post(test_url, json={}, status_code=404)
         with pytest.raises(requests.exceptions.RequestException):
+            alma_client.mark_invoice_paid(
+                invoice_id,
+                payment_date=payment_date,
+                payment_amount=payment_amount,
+                payment_currency=payment_currency,
+            )
+
+
+def test_mark_invoice_paid_request_value_error(alma_client):
+    test_url = "https://example.com/acq/invoices/558809630001021?op=paid"
+    invoice_id = "558809630001021"
+    payment_date = datetime.datetime(2021, 7, 22)
+    payment_amount = "120"
+    payment_currency = "USD"
+    mocked_response = {"payment": {"payment_status": {"value": "FOO"}}}
+    with requests_mock.Mocker(case_sensitive=True) as mocker:
+        mocker.post(test_url, json=mocked_response)
+        with pytest.raises(ValueError):
             alma_client.mark_invoice_paid(
                 invoice_id,
                 payment_date=payment_date,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,9 +99,6 @@ def test_sap_invoices_final_run_real_run(
     assert "Starting SAP invoices process with options" in caplog.text
     assert "Final run: True" in caplog.text
     assert "Real run: True" in caplog.text
-    assert (
-        "Something went wrong marking invoice '02' paid in Alma, it "
-        "should be investigated manually" in caplog.text
-    )
+    assert "Something went wrong marking invoice '02' paid in Alma." in caplog.text
     assert "SAP invoice process completed for a final run" in caplog.text
     assert "2 monograph invoices retrieved and processed:" in caplog.text


### PR DESCRIPTION
### What does this PR do?

Adds error handling and unit tests to a function that marks invoices 'paid' in alma. 

If a request error is encountered during an API call to mark an invoice 'paid', we log the invoice number and move on to the next invoice. The skipped invoices can be paid manually using API calls afterwards. 

### Helpful background context

We have been experiencing timeout errors when the app tries to mark invoices as paid. 

### Includes new or updated dependencies?

NO

### What are the relevant tickets?

https://mitlibraries.atlassian.net/browse/INFRA-381

### Developer

- [x] All new ENV is documented in README (or there is none)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
