### PR TITLE
add sap vendor id to cover sheet

### DIFF
--- a/sapinvoices/sap.py
+++ b/sapinvoices/sap.py
@@ -585,7 +585,7 @@ def generate_report(today: datetime.datetime, invoices: list[dict]) -> str:
     for invoice in invoices:
         report += f"\n\n{'':33}MIT LIBRARIES\n\n\n"
         report += f"Date: {today_string:<36}Vendor code   : {invoice['vendor']['code']}\n"
-        report += f"{'Accounting ID :':>57}\n\n"
+        report += f"{'Accounting ID :':>57} {invoice['vendor']['sap_vendor_account']}\n\n"
         report += f"Vendor:  {invoice['vendor']['name']}\n"
         for line in invoice["vendor"]["address"]["lines"]:
             report += f"         {line}\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,6 +328,8 @@ def invoices_for_sap_with_different_payment_method():
             "vendor": {
                 "name": "Danger Inc.",
                 "code": "DANGER",
+                "sap_vendor_account": "400000",
+                "sap_vendor_type_flag": "X000",
                 "address": {
                     "lines": [
                         "123 salad Street",
@@ -358,6 +360,8 @@ def invoices_for_sap_with_different_payment_method():
             "vendor": {
                 "name": "some library solutions from salad",
                 "code": "YBPE-M",
+                "sap_vendor_account": "123456",
+                "sap_vendor_type_flag": "0000",
                 "address": {
                     "lines": [
                         "P.O. Box 123456",
@@ -402,6 +406,8 @@ def invoices_for_sap_with_different_payment_method():
             "vendor": {
                 "name": "Foo Bar Books",
                 "code": "FOOBAR",
+                "sap_vendor_account": "400000",
+                "sap_vendor_type_flag": "X000",
                 "address": {
                     "lines": [
                         "123 some street",

--- a/tests/test_sap.py
+++ b/tests/test_sap.py
@@ -598,6 +598,8 @@ def test_generate_report_success():
             "currency": "USD",
             "vendor": {
                 "name": "The Bookhouse, Inc.",
+                "sap_vendor_account": "123456",
+                "sap_vendor_type_flag": "0000",
                 "code": "BKHS",
                 "address": {
                     "lines": [
@@ -639,7 +641,7 @@ def test_generate_report_success():
 
 
 Date: 10/01/2021                          Vendor code   : BKHS
-                                          Accounting ID :
+                                          Accounting ID : 123456
 
 Vendor:  The Bookhouse, Inc.
          123 Main Street


### PR DESCRIPTION
### Purpose and background context
We want to add the SAP vendor account ID to the cover page which is attached to the emails the app sends

### How can a reviewer manually see the effects of these changes?

1. generate test data in alma sandbox (there is some there already from 4/13/26)
2. perform a review run in dev environment
3. review output and see that account ID in the report is being populated with the 

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
https://mitlibraries.atlassian.net/browse/ES-3503

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

